### PR TITLE
fix custom error type in handler when return nil 

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -111,10 +111,9 @@ func Handler(h interface{}, defaultStatusCode int) http.HandlerFunc {
 			}
 		}
 
-		
 		var (
 			outputStruct interface{}
-			err interface{}
+			err          interface{}
 		)
 
 		err = nil

--- a/handler.go
+++ b/handler.go
@@ -111,7 +111,13 @@ func Handler(h interface{}, defaultStatusCode int) http.HandlerFunc {
 			}
 		}
 
-		var err, outputStruct interface{}
+		
+		var (
+			outputStruct interface{}
+			err interface{}
+		)
+
+		err = nil
 
 		// funcIn contains the input parameters of the kcd handler call.
 		var args []reflect.Value
@@ -131,10 +137,13 @@ func Handler(h interface{}, defaultStatusCode int) http.HandlerFunc {
 		ret := hv.Call(args)
 
 		if !isStdHTTPHandler {
+			errIndex := 0
 			if outType != nil {
 				outputStruct = ret[0].Interface()
-				err = ret[1].Interface()
-			} else {
+				errIndex = 1
+			}
+
+			if !ret[errIndex].IsNil() {
 				err = ret[0].Interface()
 			}
 		}

--- a/handler_test.go
+++ b/handler_test.go
@@ -137,19 +137,15 @@ func std(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("ok"))
 }
 
-
-type ErrImpl struct {}
+type ErrImpl struct{}
 
 func (t *ErrImpl) Error() string {
 	return "aaaa"
 }
 
-
 func testCustomErrNil() *ErrImpl {
 	return nil
 }
-
-
 
 func TestBind(t *testing.T) {
 	r := chi.NewRouter()
@@ -172,7 +168,6 @@ func TestBind(t *testing.T) {
 		body := e.GET("/testerrimpl").Expect().Body().Raw()
 		assert.Equal(t, "", body)
 	})
-
 
 	t.Run("it should succeed", func(t *testing.T) {
 		expect := e.POST("/4").

--- a/handler_test.go
+++ b/handler_test.go
@@ -137,10 +137,25 @@ func std(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte("ok"))
 }
 
+
+type ErrImpl struct {}
+
+func (t *ErrImpl) Error() string {
+	return "aaaa"
+}
+
+
+func testCustomErrNil() *ErrImpl {
+	return nil
+}
+
+
+
 func TestBind(t *testing.T) {
 	r := chi.NewRouter()
 
 	r.Get("/hello", kcd.Handler(std, 200))
+	r.Get("/testerrimpl", kcd.Handler(testCustomErrNil, 200))
 	r.Post("/{uint}", kcd.Handler(hookBindHandler, 200))
 
 	server := httptest.NewServer(r)
@@ -152,6 +167,12 @@ func TestBind(t *testing.T) {
 		body := e.GET("/hello").Expect().Body().Raw()
 		assert.Equal(t, "ok", body)
 	})
+
+	t.Run("it should return nil with custom error", func(t *testing.T) {
+		body := e.GET("/testerrimpl").Expect().Body().Raw()
+		assert.Equal(t, "", body)
+	})
+
 
 	t.Run("it should succeed", func(t *testing.T) {
 		expect := e.POST("/4").

--- a/internal/decoder/field_setter.go
+++ b/internal/decoder/field_setter.go
@@ -74,7 +74,7 @@ func (f fieldSetter) set() error {
 func (f fieldSetter) setForArrayOrSlice(ptr bool, list []string) error {
 	var (
 		element reflect.Value
-		array   = false
+		array   bool
 	)
 
 	isTypePtr := false

--- a/pkg/extractor/extractors_test.go
+++ b/pkg/extractor/extractors_test.go
@@ -69,7 +69,7 @@ type ExtractorTestStruct struct {
 
 	EmbeddedExtractorTest
 	*EmbeddedPtrExtractorTest
-	//embeddedQueryExtractor will don't work since it's not accessible
+	// embeddedQueryExtractor will don't work since it's not accessible
 
 	SubStruct SubStructExtractorTest
 


### PR DESCRIPTION
Support custom error type. 
However, custom type should be avoided since with custom type you can't (right now) set a custom status code easily. 